### PR TITLE
Update lang.php

### DIFF
--- a/src/lang.php
+++ b/src/lang.php
@@ -75,12 +75,14 @@ class lang extends extractor {
         }
         
         if (isset(self::$dict[$sentence])){
+            $translated_sentence=self::$dict[$sentence];
+            
             if (!empty($substitute)){
                 foreach ($substitute as $key => $val) {
-                    self::$dict[$sentence] = str_replace('{'.$key.'}', $val, self::$dict[$sentence]);
+                    $translated_sentence = str_replace('{'.$key.'}', $val, $translated_sentence);
                 }
             }
-            return self::$dict[$sentence];
+            return $translated_sentence;
         } else {
             if (!empty($substitute)){
                 foreach ($substitute as $key => $val) {


### PR DESCRIPTION
Fix issue when we use several times the same translation $LANG but with different parameters.

Example :
$LANG['Hello'] = 'Hello {Username}';

echo lang::translate('Hello', array('Username' => 'Kamille'));
echo "\n";
echo lang::translate('Hello', array('Username' => 'diversen'));

This will display :

Hello Kamille
Hello Kamille

With this fix, it will display the expected output :

Hello Kamille
Hello diversen
